### PR TITLE
Issue fixes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: glmmboot
 Type: Package
 Title: Bootstrap Resampling for Mixed Effects and Plain Models
-Version: 0.4.0
+Version: 0.5.0
 Authors@R: person("Colman", "Humphrey", email = "humphrc@tcd.ie",
   role = c("aut", "cre"))
 Description: Performs bootstrap resampling for most models that update() works for. There

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# glmmboot 0.5.0
+
+* if `parallelism = "parallel"` but `num_cores` is left as NULL, we default to using `parallel::detectCores() - 1L` cores. This was in fact the documented behaviour previously, just sadly not the actual behaviour
+* `bootstrap_model` (and internal function `bootstrap_runner`) accepts an argument `future_packages` that will be passed along to `future.apply::future.lapply`; this is needed for futures that don't share memory, because the required global isn't visible (when using S3 generics...). This is also passed along to README/vignettes/tests etc.
+* Some documentation edits, shouldn't affect functionality
+* sampling message shown by default in interactive settings
+* fixing all incorrect uses of `class` (new matrix class is the biggest change) - mostly was in tests!
+
 # glmmboot 0.4.0
 
 API changes:

--- a/R/bootstrap_ci.R
+++ b/R/bootstrap_ci.R
@@ -1,45 +1,34 @@
-#' Generating bootstrap confidence intervals
+#' Generating bootstrap confidence intervals.
 #'
 #' Enter first level estimates and second level estimates,
 #' get bootstrap interval, from the pivotal bootstrap t
 #' (Efron and Tibshirani 1994, also endorsed
 #' by Hesterberg 2015).
-#'
-#' @param base_coef_se
-#'   Estimates and SEs from full sample. In matrix form:
-#'   i.e. a (p+1) x 2 matrix, first column is estimates,
-#'   second is standard errors. This
-#'   is the output from using:
-#'   coef(summary(model_output))[,1:2, drop = FALSE]
+#' @param base_coef_se Estimates and SEs from full sample. In matrix form,
+#'   i.e. a \eqn{(p+1) x 2} matrix, first column is estimates,
+#'   second is standard errors. This is the output from using:
+#'   \code{coef(summary(model_output))[,1:2, drop = FALSE]}
 #'   or
-#'   coef(summary(model_output))$cond[,1:2, drop = FALSE]
-#'   if model_output is the output from a random
-#'   effects model (some may not have cond as the correct pull).
-#'
-#' @param resampled_coef_se
-#'   List of estimates and SEs from the bootstrapped resamples,
-#'   each list entry has the same format as the base_coef_se above.
-#'
-#' @param orig_df
-#'   Degrees of freedom to use to calculate the
+#'   \code{coef(summary(model_output))$cond[,1:2, drop = FALSE]}
+#'   if \code{model_output} is the output from a random
+#'   effects model (some may not have \code{cond} as the correct pull).
+#' @param resampled_coef_se List of estimates and SEs from the bootstrapped
+#'   resamples, each list entry has the same format as the base_coef_se above.
+#' @param orig_df Degrees of freedom to use to calculate the
 #'   t-values used for the base interval.
-#'
 #' @param alpha_level
 #'   level of CI - if you fill in \code{probs}, will use those instead
-#'
-#' @param probs
-#'   Default NULL, and will use alpha_level to set
+#' @param probs Default \code{NULL}, and will use \code{alpha_level} to set
 #'   endpoints. Else will calculate these CI endpoints.
-#'
-#' @return
-#'   A matrix containing:
-#'     Estimates;
-#'     Bootstrap interval endpoints;
-#'     Bootstrap p-value;
-#'     Base p-value;
-#'     Base interval endpoints;
-#'     Relative width of bootstrap interval to base
-#'
+#' @return A matrix containing:
+#'   \itemize{
+#'    \item Estimates
+#'    \item Bootstrap interval endpoints
+#'    \item Bootstrap p-value
+#'    \item Base p-value
+#'    \item Base interval endpoints
+#'    \item Relative width of bootstrap interval to base
+#'   }
 #' @examples
 #' x <- rnorm(20)
 #' y <- rnorm(20) + x
@@ -75,10 +64,10 @@ bootstrap_ci <- function(base_coef_se = NULL,
 
     ci_results <- Map(function(base_matrix, resampled_coef_list){
         bootstrap_individual_ci(base_matrix,
-                               resampled_coef_list,
-                               orig_df = orig_df,
-                               alpha_level = alpha_level,
-                               probs = probs)
+                                resampled_coef_list,
+                                orig_df = orig_df,
+                                alpha_level = alpha_level,
+                                probs = probs)
     }, base_coef_se, resampled_coef_lists)
 
     ## controversial: in many cases there's just one list, so just send it
@@ -92,10 +81,7 @@ bootstrap_ci <- function(base_coef_se = NULL,
 #' Runs the bootstrap estimation method for a single set of coefs (not a list)
 #'
 #' @inheritParams bootstrap_ci
-#'
-#' @return
-#'   Returns a matrix result
-#'
+#' @return Returns a matrix result
 #' @keywords internal
 bootstrap_individual_ci <- function(base_matrix = NULL,
                                     resampled_coef_list = NULL,

--- a/R/bootstrap_ci.R
+++ b/R/bootstrap_ci.R
@@ -200,23 +200,12 @@ bootstrap_individual_ci <- function(base_matrix = NULL,
     ret_matrix
 }
 
-#' gets the confidence interval and p-value for a single variable
-#'
-#' @param base_est
-#'   base model estimate
-#'
-#' @param base_se
-#'   base model SE
-#'
-#' @param resampled_ests
-#'   Vector of estimates from resampling
-#'
-#' @param resampled_ses
-#'   Vector of standard errors from resampling
-#'
-#' @return
-#'   Returns a length 3 vector: left and right CI value, and p-value
-#'
+#' Gets the confidence interval and p-value for a single variable.
+#' @param base_est Base model estimate.
+#' @param base_se Base model SE.
+#' @param resampled_ests Vector of estimates from resampling.
+#' @param resampled_ses Vector of standard errors from resampling.
+#' @return Returns a length 3 vector: left and right CI value, and p-value.
 #' @keywords internal
 ci_variable <- function(base_est,
                         base_se,
@@ -267,34 +256,21 @@ BootCI <- function(base_coef_se = NULL, # nocov start
                  probs = probs)
 } # nocov end
 
+
 #' Combines output from multiple bootstrap_model calls
 #'
 #' If you run glmmboot on e.g. a grid of computers,
-#' set return_coefs_instead = TRUE for each.
+#' set \code{return_coefs_instead = TRUE} for each.
 #' Then enter them all here. Either just list them out,
 #' or put them into one list and enter them.
-#'
-#' @param ...
-#'   Say our output from bootstrap_model from three separate computers is
-#'   output_list1,
-#'   output_list2,
-#'   output_list3
-#'   We can run: combine_resampled_lists(output_list1,
-#'                                       output_list2,
-#'                                       output_list3)
-#'   OR: create a list of lists:
-#'   output_list_list <- list(output_list1, output_list2, output_list3)
-#'   and then: combine_resampled_lists(output_list_list)
-#'
-#' @param return_combined_list
-#'   Logical, default FALSE. TRUE if you want the combined
-#'   list of lists, FALSE for just the output from bootstrap_ci applied to it.
-#'
-#' @return
-#'   Returns the same output as bootstrap_ci by default,
+#' @param ... List of outputs to be combined, or just a bunch of output entries
+#'   as separate unnamed arguments.
+#' @param return_combined_list Logical, default \code{FALSE}.
+#'   \code{TRUE} if you want the combined list of lists,
+#'   \code{FALSE} for just the output from bootstrap_ci applied to it.
+#' @return Returns the same output as \code{bootstrap_ci} by default,
 #'   or the combined list (as if you had just run bootstrap_model once with
-#'   all resamples) if return_combined_list = TRUE
-#'
+#'   all resamples) if \code{return_combined_list = TRUE}
 #' @examples
 #' \donttest{
 #'   data(test_data)

--- a/R/bootstrap_methods.R
+++ b/R/bootstrap_methods.R
@@ -195,7 +195,7 @@ get_rand <- function(form_with_bars){
     first_pass <- unlist(
         lapply(findbar_list,
                function(x){
-                   if (class(x) == "call") {
+                   if (inherits(x "call")) {
                        return(as.character(x[3])) # nocov
                    } else {
                        first_bar <- unlist(gregexpr("|", x, fixed = TRUE))[[1]]

--- a/R/bootstrap_methods.R
+++ b/R/bootstrap_methods.R
@@ -2,27 +2,17 @@
 #'
 #' Takes in a list of unique levels in the random columns,
 #' gives back a random sampling of each.
-#'
-#' @param list_of_levels
-#'   list of vectors of levels of each random effect
-#'
-#' @param rand_columns
-#'   Default NULL.
-#'   name of columns to randomise over; if NULL, will use
-#'   all in 'list_of_levels'
-#'
-#' @param unique_resample_lim
-#'   Default NULL; optionally set a minimal number of unique levels each sample
+#' @param list_of_levels List of vectors of levels of each random effect.
+#' @param rand_columns Default \code{NULL}. Name of columns to randomise over;
+#'   if \code{NULL}, will use all in \code{list_of_levels}
+#' @param unique_resample_lim Default \code{NULL};
+#'   optionally set a minimal number of unique levels each sample
 #'   must produce. Note that it should be a named vector,
 #'   the same as the levels to randomise over.
-#'
-#' @param reduce_by_one
-#'   Logical, default TRUE; for (potentially) more accurate coverage,
-#'   resample one less than the number of levels in each list
-#'
-#' @return
-#'   A list of samples
-#'
+#' @param reduce_by_one Logical, default \code{TRUE};
+#'   for greater coverage,
+#'   resample one less than the number of levels in each list.
+#' @return A list of samples
 #' @keywords internal
 gen_sample <- function(list_of_levels,
                        rand_columns = NULL,
@@ -43,20 +33,14 @@ gen_sample <- function(list_of_levels,
     temp
 }
 
+
 #' For resampling from a single set of levels
 #'
-#' @param levels
-#'   The levels to sample
-#'
-#' @param unique_lim
-#'   Default NULL; optionally a required number of unique
-#'   elements to have in the sample
-#'
+#' @param levels The levels to sample.
+#' @param unique_lim Default \code{NULL};
+#'   optionally a required number of unique elements to have in the sample
 #' @inheritParams gen_sample
-#'
-#' @return
-#' A sample of 'levels'; a vector.
-#'
+#' @return A sample of \code{levels}; a vector.
 #' @keywords internal
 gen_samp_lev <- function(levels,
                          unique_lim = NULL,
@@ -90,21 +74,17 @@ gen_samp_lev <- function(levels,
 }
 
 
-
 #' Finds all occurrences of new_vector in orig_vector
 #'
 #' For each value in new_vector, we find the indices of ALL
 #' matching values in orig_vector. This means that if new_vector
 #' has duplicates, we'll duplicate the indices from orig_vector too
-#'
-#' @param orig_vector vector to find indices from
-#' @param new_vector vector to match values to (from orig_vector)
-#' @param current_index accumulator of the indices so far, for recursion
-#' @return returns a vector of indices from orig_vector that correspond to
-#' values in new_vector
-#'
+#' @param orig_vector Vector to find indices from.
+#' @param new_vector Vector to match values to (from \code{orig_vector}).
+#' @param current_index Accumulator of the indices so far, for recursion.
+#' @return Returns a vector of indices from orig_vector that correspond to
+#'   values in new_vector.
 #' @examples
-#'
 #' \donttest{
 #'     orig_vector <- c(1, 1, 2, 3, 3, 3)
 #'     new_vector <- c(1, 2, 1)
@@ -131,19 +111,12 @@ gen_vector_match <- function(orig_vector,
 
 #' Given resampled vectors, gives matching index of original variables
 #'
-#' this function takes in original vectors, and resampled editions,
+#' This function takes in original vectors, and resampled editions,
 #' it spits back the matching index of the original variables
-#' for the new resampled ones
-#'
-#' @param orig_list
-#' List of original data vectors
-#'
-#' @param sampled_list
-#' Sampled list
-#'
-#' @return
-#' Returns an index vector
-#'
+#' for the new resampled ones.
+#' @param orig_list List of original data vectors.
+#' @param sampled_list Sampled list
+#' @return Returns an index vector.
 #' @keywords internal
 gen_resampling_index <- function(orig_list,
                                  sampled_list){
@@ -169,18 +142,12 @@ gen_resampling_index <- function(orig_list,
 }
 
 
-#' this takes in a formula with bars
+#' Takes in a formula with bars
 #' and gives back the plain names of the columns
-#'
-#' @param form_with_bars
-#' A formula used in e.g. lme4 and similar
-#' packages. Typically along the lines:
-#' y ~ age + (1 | school)
-#' etc
-#'
-#' @return A vector of the variables that
-#' are treated as random
-#'
+#' @param form_with_bars A formula used in e.g. \code{lme4} and similar
+#'   packages. Typically along the lines:
+#'   \code{y ~ age + (1 | school)} etc
+#' @return A vector of the variables that are treated as random.
 #' @examples
 #' get_rand("y ~ age + (1 | school)")
 #' get_rand("y ~ income + (1 | school) + (1 | school:section)")
@@ -214,10 +181,10 @@ get_rand <- function(form_with_bars){
     all_vars[in_firstpass]
 }
 
+
 #' Returns the terms with bars from a formula
 #'
 #' @inheritParams get_rand
-#'
 #' @keywords internal
 find_bars <- function(form_with_bars){
     ## if it's just text right now, convert it
@@ -232,6 +199,7 @@ find_bars <- function(form_with_bars){
     as.list(form_terms[grepl("|", form_terms, fixed = TRUE)])
 }
 
+
 #' Calculate Shannon Entropy
 #' @keywords internal
 calc_entropy <- function(level_vector){
@@ -244,17 +212,11 @@ calc_entropy <- function(level_vector){
 #'
 #' Checks that an object is a list, and also
 #' that the list is a collection of matrices.
-#' Currently returns FALSE on an empty list
-#'
-#' @param list_to_check
-#' The "list" (maybe!) to check
-#'
-#' @param allow_null
-#' If an element is NULL, is that OK?
-#'
-#' @return
-#' TRUE or FALSE
-#'
+#' Currently returns \code{FALSE} on an empty list
+#' @param list_to_check The potential list to check
+#' @param allow_null If an element is \code{NULL}, is that OK?
+#'   Default \code{TRUE}
+#' @return Logical
 #' @keywords internal
 list_of_matrices <- function(list_to_check,
                              allow_null = TRUE){
@@ -277,20 +239,16 @@ list_of_matrices <- function(list_to_check,
     })))
 }
 
+
 #' Checks if the result of bootstrap_coef_est is not error
 #'
 #' For each element of the list of results
 #' from running bootstrap_coef_est, checks if it's
 #' a list of matrices, and that each matrix has no missing values
-#'
-#' @param coef_list_list
-#' list of results from running bootstrap_coef_est,
-#' e.g. lapply(1:N, bootstrap_coef_est)
-#'
-#' @return
-#' A logical vector, TRUE if the element is indeed a list of matrices
-#' with non-missing entries
-#'
+#' @param coef_list_list List of results from running \code{bootstrap_coef_est},
+#'   e.g. \code{lapply(1:N, bootstrap_coef_est)}
+#' @return A logical vector, \code{TRUE} if the element is indeed
+#'   a list of matrices with non-missing entries
 #' @keywords internal
 not_error_check <- function(coef_list_list){
     unlist(lapply(coef_list_list, function(coef_list){

--- a/R/bootstrap_methods.R
+++ b/R/bootstrap_methods.R
@@ -221,7 +221,7 @@ get_rand <- function(form_with_bars){
 #' @keywords internal
 find_bars <- function(form_with_bars){
     ## if it's just text right now, convert it
-    if (!("formula" %in% class(form_with_bars))) {
+    if (!inherits(form_with_bars, "formula")) {
         form_with_bars <- as.formula(form_with_bars)
     }
 
@@ -258,7 +258,7 @@ calc_entropy <- function(level_vector){
 #' @keywords internal
 list_of_matrices <- function(list_to_check,
                              allow_null = TRUE){
-    if (!("list" %in% class(list_to_check))) {
+    if (!inherits(list_to_check, "list")) {
         return(FALSE)
     }
 
@@ -267,7 +267,7 @@ list_of_matrices <- function(list_to_check,
     }
 
     all(unlist(lapply(list_to_check, function(maybe_mat){
-        if ("matrix" %in% class(maybe_mat)) {
+        if (is.matrix(maybe_mat)) {
             return(TRUE)
         }
         if (allow_null && is.null(maybe_mat)) {
@@ -295,8 +295,7 @@ list_of_matrices <- function(list_to_check,
 not_error_check <- function(coef_list_list){
     unlist(lapply(coef_list_list, function(coef_list){
         all(unlist(lapply(coef_list, function(coef_maybe_mat){
-            "matrix" %in% class(coef_maybe_mat) &&
-                !anyNA(coef_maybe_mat)
+            is.matrix(coef_maybe_mat) && !anyNA(coef_maybe_mat)
         })))
     }))
 }

--- a/R/bootstrap_methods.R
+++ b/R/bootstrap_methods.R
@@ -162,7 +162,7 @@ get_rand <- function(form_with_bars){
     first_pass <- unlist(
         lapply(findbar_list,
                function(x){
-                   if (inherits(x "call")) {
+                   if (inherits(x, "call")) {
                        return(as.character(x[3])) # nocov
                    } else {
                        first_bar <- unlist(gregexpr("|", x, fixed = TRUE))[[1]]
@@ -240,11 +240,11 @@ list_of_matrices <- function(list_to_check,
 }
 
 
-#' Checks if the result of bootstrap_coef_est is not error
+#' Checks if the result of \code{bootstrap_coef_est} is not error
 #'
-#' For each element of the list of results
-#' from running bootstrap_coef_est, checks if it's
-#' a list of matrices, and that each matrix has no missing values
+#' For each element of the list of results from running
+#' \code{bootstrap_coef_est}, checks if it's a list of matrices,
+#' and that each matrix has no missing values
 #' @param coef_list_list List of results from running \code{bootstrap_coef_est},
 #'   e.g. \code{lapply(1:N, bootstrap_coef_est)}
 #' @return A logical vector, \code{TRUE} if the element is indeed

--- a/R/bootstrap_model.R
+++ b/R/bootstrap_model.R
@@ -181,6 +181,11 @@ bootstrap_model <- function(base_model,
         }
     }
 
+    if (parallelism != "future" && !is.null(future_packages)) {
+        stop("Argument `future_packages` should only be set when ",
+             "using `parallelism = \"future\"`", call. = FALSE)
+    }
+
     ##------------------------------------
 
     ## formula processing

--- a/R/bootstrap_model.R
+++ b/R/bootstrap_model.R
@@ -379,28 +379,17 @@ BootGlmm <- function(base_model, # nocov start
                     suppress_sampling_message = suppress_sampling_message)
 } # nocov end
 
-#' Runs the bootstrapping of the models
+
+#' Runs the bootstrapping of the models.
 #'
 #' This function gets passed a function that runs a single bootstrap resample
 #' and a number of resamples, and decides how to run them
-#' e.g. in parallel etc
-#'
-#' @param bootstrap_function
-#'   a function that we wish to run `resamples` times
-#'
-#' @param resamples
-#'   how many times we wish to run `bootstrap_function`
-#'
-#' @param parallelism
-#'   How to run this function in parallel
-#'
-#' @param num_cores
-#'   How many cores to use, if using `parallel`
-#'
-#' @return
-#'   returns the list that contains the results of running
-#'   `bootstrap_function`.
-#'
+#' e.g. in parallel etc.
+#' @param bootstrap_function Function that we wish to run
+#'   \code{resamples} times.
+#' @inheritParams bootstrap_model
+#' @return Returns the list that contains the results of running
+#'   \code{bootstrap_function}.
 #' @keywords internal
 bootstrap_runner <- function(bootstrap_function,
                              resamples,

--- a/R/bootstrap_model.R
+++ b/R/bootstrap_model.R
@@ -173,11 +173,11 @@ bootstrap_model <- function(base_model,
                      "but it's not installed", call. = FALSE)
             } # nocov end
 
-            if (is.null(num_cores)) {
+            if (is.null(num_cores)) { # nocov start
                 num_cores <- max(parallel::detectCores() - 1L, 1L)
                 message("`num_cores` not set, defaulting to ", num_cores,
                         " (`parallel::detectCores() - 1L`)")
-            }
+            } # nocov end
         }
     }
 
@@ -323,7 +323,7 @@ bootstrap_model <- function(base_model,
     }
 
     ## keep going until solved
-    max_redos <- 10L
+    max_redos <- 15L
     redo_iter <- 1L
     while (sum(error_ind) > 0L && redo_iter <= max_redos) {
         message(sum(error_ind), " error(s) to redo")

--- a/R/bootstrap_model.R
+++ b/R/bootstrap_model.R
@@ -50,7 +50,8 @@
 #'   depending on existence of random effects). If \code{FALSE}, will do
 #'   typical size n resampling.
 #' @param num_cores How many cores to use.
-#'   Defaults to parallel::detectCores() - 1 if parallelism = "parallel"
+#'   Defaults to \code{parallel::detectCores() - 1L} if
+#'   \code{parallelism = "parallel"}
 #' @param suppress_sampling_message Logical, the default is
 #'   to supress if not in an interactive session.
 #'   Do you want the function to message the console with the type of
@@ -165,6 +166,12 @@ bootstrap_model <- function(base_model,
                 stop("`parallelism = \"parallel\"` uses `package:parallel`, ",
                      "but it's not installed", call. = FALSE)
             } # nocov end
+
+            if (is.null(num_cores)) {
+                num_cores <- max(parallel::detectCores() - 1L, 1L)
+                message("`num_cores` not set, defaulting to ", num_cores,
+                        " (`parallel::detectCores() - 1L`)")
+            }
         }
     }
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -10,6 +10,9 @@ knitr::opts_chunk$set(
   comment = "#",
   fig.path = "README-"
 )
+options(warnPartialMatchArgs = FALSE,
+        warnPartialMatchDollar = FALSE,
+        warnPartialMatchAttr = FALSE)
 ```
 
 # glmmboot
@@ -85,6 +88,7 @@ devtools::install_github("ColmanHumphrey/glmmboot")
 We'll provide a quick example using glm. First we'll set up some data:
 
 ```{r}
+set.seed(15278086) # Happy for Nadia and Alan
 x1 <- rnorm(50)
 x2 <- runif(50)
 
@@ -110,7 +114,6 @@ Let's run a bootstrap.
 
 ```{r}
 library(glmmboot)
-set.seed(15278086) # Happy for Nadia and Alan
 boot_results <- bootstrap_model(base_model = base_run,
                                 base_data = sample_frame,
                                 resamples = 999)

--- a/README.Rmd
+++ b/README.Rmd
@@ -22,7 +22,7 @@ knitr::opts_chunk$set(
 
 ## Overview
 
-glmmboot provides a simple interface for creating bootstrap 
+glmmboot provides a simple interface for creating bootstrap
 confidence intervals using a wide set of models. The primary function
 is `bootstrap_model`, which has three primary arguments:
 
@@ -31,14 +31,14 @@ is `bootstrap_model`, which has three primary arguments:
 * `resamples`: how many bootstrap resamples you wish to perform
 
 Another function, `bootstrap_ci`, converts output from
-bootstrap model runs into confidence intervals and p-values. 
+bootstrap model runs into confidence intervals and p-values.
 By default, `bootstrap_model` calls `bootstrap_ci`.
 
 ## Types of bootstrapping
 
 For models with random effects:
 
-* the default (and recommended) behaviour will be to block sample over the effect with the largest entropy 
+* the default (and recommended) behaviour will be to block sample over the effect with the largest entropy
 (generally the one with the most levels)
 * it's also possible to specify multiple random effects to block sample over
 
@@ -46,7 +46,7 @@ With no random effects, performs case resampling: resamples each row with replac
 
 ## Requirements:
 
-1. the model should work with the 
+1. the model should work with the
 function `update`, to change the data
 2. the coefficients are extractable using `coef(summary(model))`
   + either directly, i.e. this gives a matrix
@@ -56,12 +56,14 @@ produce two matrices of coefficients
 ## Parallel
 
 It may be desired to run this package in parallel. The best way is
-to use the `future` backend, which uses `future.apply::future_lapply`. 
+to use the `future` backend, which uses `future.apply::future_lapply`.
 You do that by specifying the backend through the
-`future::plan` setup, and then setting `parallelism = "future"`. See the Quick Use 
+`future::plan` setup, and then setting `parallelism = "future"`. It's quite
+possible you'll want to pass the package used to build the model to the argument
+`future_packages`. See the Quick Use
 vignette for more.
 
-It's also easy to use `parallel::mclapply`; again, see the Quick Use 
+It's also easy to use `parallel::mclapply`; again, see the Quick Use
 vignette.
 
 ## Installation
@@ -98,8 +100,8 @@ sample_frame <- data.frame(x1 = x1, x2 = x2, y = y)
 Typically this model is fit with logistic regression:
 
 ```{r}
-base_run <- glm(y ~ x1 + x2, 
-                family = binomial(link = 'logit'), 
+base_run <- glm(y ~ x1 + x2,
+                family = binomial(link = 'logit'),
                 data = sample_frame)
 summary(base_run)
 ```
@@ -109,7 +111,7 @@ Let's run a bootstrap.
 ```{r}
 library(glmmboot)
 set.seed(15278086) # Happy for Nadia and Alan
-boot_results <- bootstrap_model(base_model = base_run, 
+boot_results <- bootstrap_model(base_model = base_run,
                                 base_data = sample_frame,
                                 resamples = 999)
 ```
@@ -119,7 +121,7 @@ And the results:
 print(boot_results)
 ```
 
-The estimates are the same, since we just pull from the base model. The intervals are 
+The estimates are the same, since we just pull from the base model. The intervals are
 similar to the base model, although slightly narrower: typical logistic regression is fractionally
 conservative at `N = 50`.
 
@@ -146,8 +148,8 @@ Let's run the bootstrap (ignore the actual results, 3 resamples is basically mea
 ```{r}
 zi_results <- bootstrap_model(base_model = fit_zipoisson,
                               base_data = owls,
-                              resamples = 3,
-                              parallelism = "future")
+                              resamples = 3)
+
 print(zi_results)
 ```
 
@@ -159,5 +161,6 @@ plan("multiprocess")
 zi_results <- bootstrap_model(base_model = fit_zipoisson,
                               base_data = owls,
                               resamples = 1000,
-                              parallelism = "future")
+                              parallelism = "future",
+                              future_packages = "glmmTMB")
 ```

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,17 +1,13 @@
 ## Release Summary
 
-For the most part, functionality is not fundamentally changed in terms of the results from the primary functions in common situations.
+As requested, fixes issues where `class()` was assumed to return a length-one result (mostly was used in testing). All should be done now.
 
-Some functionality changes:
-* gen_resampling_index is now better in many ways, including more performative, but should return the same results as before
-* parallel backends more robustly setup, including support for `future.apply::future_lapply`
-* The code now works correctly in situations where the base model returns a list of coefficients
+Apart from that, primary change is to add a better default for `parallelism = "parallel"`, and to provide a solve for issues with `parallelism = "future"`:
 
-Naming changes:
-* Any function that didn't have a snake_case name now has one, including most notably the two main exported functions, `bootstrap_model` and `bootstrap_ci`. The old version still exist and are marked as deprecated.
-* very mild reordering of the arguments for bootstrap_model, to reflect that the base_data should be supplied in basically all circumstances
+* if `parallelism = "parallel"` but `num_cores` is left as NULL, we default to using `parallel::detectCores() - 1L` cores. This was in fact the documented behaviour previously, just sadly not the actual behaviour
+* `bootstrap_model` (and internal function `bootstrap_runner`) accepts an argument `future_packages` that will be passed along to `future.apply::future.lapply`; this is needed for futures that don't share memory, because the required global isn't visible (when using S3 generics). This is also passed along to README/vignettes/tests etc.
 
-Further: added code coverage
+Some very minor documentation and messaging edits rounds out the submission.
 
 ## Test environments
 * local OS X install, R 3.6.1

--- a/man/bootstrap_ci.Rd
+++ b/man/bootstrap_ci.Rd
@@ -3,7 +3,7 @@
 \name{bootstrap_ci}
 \alias{bootstrap_ci}
 \alias{BootCI}
-\title{Generating bootstrap confidence intervals}
+\title{Generating bootstrap confidence intervals.}
 \usage{
 bootstrap_ci(base_coef_se = NULL, resampled_coef_se = NULL,
   orig_df = NULL, alpha_level = 0.05, probs = NULL)
@@ -12,37 +12,38 @@ BootCI(base_coef_se = NULL, resampled_coef_se = NULL, orig_df = NULL,
   alp_level = 0.05, probs = NULL)
 }
 \arguments{
-\item{base_coef_se}{Estimates and SEs from full sample. In matrix form:
-i.e. a (p+1) x 2 matrix, first column is estimates,
-second is standard errors. This
-is the output from using:
-coef(summary(model_output))[,1:2, drop = FALSE]
+\item{base_coef_se}{Estimates and SEs from full sample. In matrix form,
+i.e. a \eqn{(p+1) x 2} matrix, first column is estimates,
+second is standard errors. This is the output from using:
+\code{coef(summary(model_output))[,1:2, drop = FALSE]}
 or
-coef(summary(model_output))$cond[,1:2, drop = FALSE]
-if model_output is the output from a random
-effects model (some may not have cond as the correct pull).}
+\code{coef(summary(model_output))$cond[,1:2, drop = FALSE]}
+if \code{model_output} is the output from a random
+effects model (some may not have \code{cond} as the correct pull).}
 
-\item{resampled_coef_se}{List of estimates and SEs from the bootstrapped resamples,
-each list entry has the same format as the base_coef_se above.}
+\item{resampled_coef_se}{List of estimates and SEs from the bootstrapped
+resamples, each list entry has the same format as the base_coef_se above.}
 
 \item{orig_df}{Degrees of freedom to use to calculate the
 t-values used for the base interval.}
 
 \item{alpha_level}{level of CI - if you fill in \code{probs}, will use those instead}
 
-\item{probs}{Default NULL, and will use alpha_level to set
+\item{probs}{Default \code{NULL}, and will use \code{alpha_level} to set
 endpoints. Else will calculate these CI endpoints.}
 
 \item{alp_level}{now alpha_level}
 }
 \value{
 A matrix containing:
-    Estimates;
-    Bootstrap interval endpoints;
-    Bootstrap p-value;
-    Base p-value;
-    Base interval endpoints;
-    Relative width of bootstrap interval to base
+  \itemize{
+   \item Estimates
+   \item Bootstrap interval endpoints
+   \item Bootstrap p-value
+   \item Base p-value
+   \item Base interval endpoints
+   \item Relative width of bootstrap interval to base
+  }
 }
 \description{
 Enter first level estimates and second level estimates,

--- a/man/bootstrap_individual_ci.Rd
+++ b/man/bootstrap_individual_ci.Rd
@@ -13,7 +13,7 @@ t-values used for the base interval.}
 
 \item{alpha_level}{level of CI - if you fill in \code{probs}, will use those instead}
 
-\item{probs}{Default NULL, and will use alpha_level to set
+\item{probs}{Default \code{NULL}, and will use \code{alpha_level} to set
 endpoints. Else will calculate these CI endpoints.}
 }
 \value{

--- a/man/bootstrap_model.Rd
+++ b/man/bootstrap_model.Rd
@@ -3,14 +3,14 @@
 \name{bootstrap_model}
 \alias{bootstrap_model}
 \alias{BootGlmm}
-\title{computes bootstrap resamples of your data,
+\title{Computes bootstrap resamples of your data,
 stores estimates + SEs.}
 \usage{
 bootstrap_model(base_model, base_data, resamples = 9999,
   return_coefs_instead = FALSE, parallelism = c("none", "future",
   "parallel"), resample_specific_blocks = NULL,
   unique_resample_lim = NULL, narrowness_avoid = TRUE,
-  num_cores = NULL, suppress_sampling_message = FALSE)
+  num_cores = NULL, suppress_sampling_message = !interactive())
 
 BootGlmm(base_model, resamples = 9999, base_data = NULL,
   return_coefs_instead = FALSE, resample_specific_blocks = NULL,
@@ -22,85 +22,91 @@ BootGlmm(base_model, resamples = 9999, base_data = NULL,
 \item{base_model}{The pre-bootstrap model, i.e. the model output
 from running a standard model call.
 Examples:
-base_model <- glmmTMB(y ~ age + (1 | subj),
-                      data = rel_data, family = binomial)
-base_model <- lm(y ~ x, data = xy_frame)}
+\code{base_model <- glmmTMB(y ~ age + (1 | subj),
+                      data = rel_data, family = binomial)}
+\code{base_model <- lm(y ~ x, data = xy_frame)}}
 
 \item{base_data}{The data that was used in the call. You
 can leave this to be automatically read, but
 I highly recommend supplying it}
 
 \item{resamples}{How many resamples of your data do you want to do?
-9999 is a reasonable default (see Hesterberg 2015),
+9,999 is a reasonable default (see Hesterberg 2015),
 but start very small to make sure it works on
 your data properly, and to get a rough timing estimate etc.}
 
-\item{return_coefs_instead}{Logical, default FALSE: do you want the list of lists
-of results for each bootstrap sample (set to TRUE), or the
+\item{return_coefs_instead}{Logical, default \code{FALSE}: do you want the
+list of lists of results for each bootstrap sample (set to \code{TRUE}), or the
 matrix output of all samples? See return for more details.}
 
-\item{parallelism}{What type of parallelism (if any) to use to run the resamples.
+\item{parallelism}{Type of parallelism (if any) to use to run the resamples.
 Options are:
-- "none"      the default
-- "future"    to use future.apply (`future`s)
-- "parallel"  to use parallel::mclapply}
+\describe{
+  \item{\code{"none"}}{The default, sequential}
+  \item{\code{"future"}}{To use \code{future.apply} (\code{future}s)}
+  \item{\code{"parallel"}}{To use \code{parallel::mclapply}}
+}}
 
-\item{resample_specific_blocks}{Character vector, default NULL. If left NULL,
-  this algorithm with choose ONE random block to resample over -
-  the one with the largest entropy (often the one with most levels).
-  If you wish to
-  resample over specific random effects as blocks, enter
-  the names here - can be one, or many. Note that resampling
-  multiple blocks is in general quite conservative.
+\item{resample_specific_blocks}{Character vector, default \code{NULL}.
+If left \code{NULL}, this algorithm with choose ONE random block to resample over -
+the one with the largest entropy (often the one with most levels).
+If you wish to resample over specific random effects as blocks, enter
+the names here - can be one, or many. Note that resampling
+multiple blocks is in general quite conservative.
+If you want to perform case resampling but you DO have
+random effects, set \code{resample_specific_blocks} to any
+non-null value that isn't equal to a random effect
+variable name.}
 
-  If you want to perform case resampling but you DO have
-  random effects, set resample_specific_blocks to any
-  non-null value that isn't equal to a random effect
-  variable name.}
-
-\item{unique_resample_lim}{Should be same length as number of random effects (or left NULL).
+\item{unique_resample_lim}{Should be same length as number of random effects
+(or left \code{NULL}).
 Do you want to force the resampling to produce a minimum number of
-unique values in sampling? Don't make this too big...
+unique values in sampling? Don't make this too big.
 Must be named same as rand cols}
 
-\item{narrowness_avoid}{Boolean, default TRUE.
-If TRUE, will resample n-1 instead of n elements
-in the bootstrap (n being either rows, or random effect levels,
-depending on existence of random effects). If FALSE, will do
+\item{narrowness_avoid}{Boolean, default \code{TRUE}. If \code{TRUE}, will resample n-1
+instead of n elements in the bootstrap (n being either rows,
+or random effect levels,
+depending on existence of random effects). If \code{FALSE}, will do
 typical size n resampling.}
 
-\item{num_cores}{Defaults to parallel::detectCores() - 1 if parallelism = "parallel"}
+\item{num_cores}{How many cores to use.
+Defaults to \code{parallel::detectCores() - 1L} if
+\code{parallelism = "parallel"}}
 
-\item{suppress_sampling_message}{Logical, default FALSE. By default, this function
-will message the console with the type of bootstrapping:
-block resampling over random effects - in which case it'll say
-what effect it's sampling over;
-case resampling - in which case it'll say as much.
-Set TRUE to hide message.}
+\item{suppress_sampling_message}{Logical, the default is
+to supress if not in an interactive session.
+Do you want the function to message the console with the type of
+bootstrapping? If block resampling over random effects, then it'll say
+what effect it's sampling over; if case resampling -
+in which case it'll say as much.
+Set \code{TRUE} to hide message.}
 
 \item{suppress_loading_bar}{defunct now}
 
 \item{allow_conv_error}{defunct now}
 }
 \value{
-By default, returns the output from bootstrap_ci:
-    - for each set of covariates (usually just the one set,
-      the conditional model), a matrix of output, a row for each variable,
-      including the intercept
-      (estimate, CIs for boot and base, p-values).
-  If return_coefs_instead = TRUE, then will instead
+By default (with \code{return_coefs_instead} being \code{FALSE}),
+  returns the output from \code{bootstrap_ci};
+  for each set of covariates (usually just the one set,
+  the conditional model) we get a matrix of output: a row for each variable
+  (including the intercept),
+  estimate, CIs for boot and base, p-values.
+  If \code{return_coefs_instead} is \code{TRUE}, then will instead
   return a list of length two:
-  [[1]] will be a list containing the output for the base model
-  [[2]] will be a list of length resamples,
-  each a list of matrices of estimates and standard errors for each model.
+  \itemize{
+    \item a list containing the output for the base model
+    \item a list of length \code{resamples} each a list of matrices of
+      estimates and standard errors for each model.
+  }
   This output is useful for error checking, and if you want
   to run this function in certain distributed ways.
 }
 \description{
 By default, this will compute bootstrap resamples
-and then send them to `bootstrap_ci`
-for calculation. Note - only use parallel methods if your
-model is expensive to build, otherwise the overhead won't be worth it.
+and then send them to \code{bootstrap_ci}
+for calculation.
 }
 \examples{
 x <- rnorm(20)

--- a/man/bootstrap_model.Rd
+++ b/man/bootstrap_model.Rd
@@ -10,7 +10,8 @@ bootstrap_model(base_model, base_data, resamples = 9999,
   return_coefs_instead = FALSE, parallelism = c("none", "future",
   "parallel"), resample_specific_blocks = NULL,
   unique_resample_lim = NULL, narrowness_avoid = TRUE,
-  num_cores = NULL, suppress_sampling_message = !interactive())
+  num_cores = NULL, future_packages = NULL,
+  suppress_sampling_message = !interactive())
 
 BootGlmm(base_model, resamples = 9999, base_data = NULL,
   return_coefs_instead = FALSE, resample_specific_blocks = NULL,
@@ -73,6 +74,12 @@ typical size n resampling.}
 \item{num_cores}{How many cores to use.
 Defaults to \code{parallel::detectCores() - 1L} if
 \code{parallelism = "parallel"}}
+
+\item{future_packages}{Packages to pass to created futures when
+using \code{parallelism = "future"}. This must be supplied if
+the package used to model the data isn't in base and you're
+using a plan that doesn't have shared memory, because the
+model is updated with the S3 generic \code{update}.}
 
 \item{suppress_sampling_message}{Logical, the default is
 to supress if not in an interactive session.

--- a/man/bootstrap_runner.Rd
+++ b/man/bootstrap_runner.Rd
@@ -2,27 +2,45 @@
 % Please edit documentation in R/bootstrap_model.R
 \name{bootstrap_runner}
 \alias{bootstrap_runner}
-\title{Runs the bootstrapping of the models}
+\title{Runs the bootstrapping of the models.}
 \usage{
 bootstrap_runner(bootstrap_function, resamples, parallelism = c("none",
-  "future", "parallel"), num_cores = NULL)
+  "future", "parallel"), num_cores = NULL, future_packages = NULL)
 }
 \arguments{
-\item{bootstrap_function}{a function that we wish to run `resamples` times}
+\item{bootstrap_function}{Function that we wish to run
+\code{resamples} times.}
 
-\item{resamples}{how many times we wish to run `bootstrap_function`}
+\item{resamples}{How many resamples of your data do you want to do?
+9,999 is a reasonable default (see Hesterberg 2015),
+but start very small to make sure it works on
+your data properly, and to get a rough timing estimate etc.}
 
-\item{parallelism}{How to run this function in parallel}
+\item{parallelism}{Type of parallelism (if any) to use to run the resamples.
+Options are:
+\describe{
+  \item{\code{"none"}}{The default, sequential}
+  \item{\code{"future"}}{To use \code{future.apply} (\code{future}s)}
+  \item{\code{"parallel"}}{To use \code{parallel::mclapply}}
+}}
 
-\item{num_cores}{How many cores to use, if using `parallel`}
+\item{num_cores}{How many cores to use.
+Defaults to \code{parallel::detectCores() - 1L} if
+\code{parallelism = "parallel"}}
+
+\item{future_packages}{Packages to pass to created futures when
+using \code{parallelism = "future"}. This must be supplied if
+the package used to model the data isn't in base and you're
+using a plan that doesn't have shared memory, because the
+model is updated with the S3 generic \code{update}.}
 }
 \value{
-returns the list that contains the results of running
-  `bootstrap_function`.
+Returns the list that contains the results of running
+  \code{bootstrap_function}.
 }
 \description{
 This function gets passed a function that runs a single bootstrap resample
 and a number of resamples, and decides how to run them
-e.g. in parallel etc
+e.g. in parallel etc.
 }
 \keyword{internal}

--- a/man/ci_variable.Rd
+++ b/man/ci_variable.Rd
@@ -2,23 +2,23 @@
 % Please edit documentation in R/bootstrap_ci.R
 \name{ci_variable}
 \alias{ci_variable}
-\title{gets the confidence interval and p-value for a single variable}
+\title{Gets the confidence interval and p-value for a single variable.}
 \usage{
 ci_variable(base_est, base_se, resampled_ests, resampled_ses, probs)
 }
 \arguments{
-\item{base_est}{base model estimate}
+\item{base_est}{Base model estimate.}
 
-\item{base_se}{base model SE}
+\item{base_se}{Base model SE.}
 
-\item{resampled_ests}{Vector of estimates from resampling}
+\item{resampled_ests}{Vector of estimates from resampling.}
 
-\item{resampled_ses}{Vector of standard errors from resampling}
+\item{resampled_ses}{Vector of standard errors from resampling.}
 }
 \value{
-Returns a length 3 vector: left and right CI value, and p-value
+Returns a length 3 vector: left and right CI value, and p-value.
 }
 \description{
-gets the confidence interval and p-value for a single variable
+Gets the confidence interval and p-value for a single variable.
 }
 \keyword{internal}

--- a/man/combine_resampled_lists.Rd
+++ b/man/combine_resampled_lists.Rd
@@ -10,28 +10,21 @@ combine_resampled_lists(..., return_combined_list = FALSE)
 CombineResampledLists(..., return_combined_list = FALSE)
 }
 \arguments{
-\item{...}{Say our output from bootstrap_model from three separate computers is
-output_list1,
-output_list2,
-output_list3
-We can run: combine_resampled_lists(output_list1,
-                                    output_list2,
-                                    output_list3)
-OR: create a list of lists:
-output_list_list <- list(output_list1, output_list2, output_list3)
-and then: combine_resampled_lists(output_list_list)}
+\item{...}{List of outputs to be combined, or just a bunch of output entries
+as separate unnamed arguments.}
 
-\item{return_combined_list}{Logical, default FALSE. TRUE if you want the combined
-list of lists, FALSE for just the output from bootstrap_ci applied to it.}
+\item{return_combined_list}{Logical, default \code{FALSE}.
+\code{TRUE} if you want the combined list of lists,
+\code{FALSE} for just the output from bootstrap_ci applied to it.}
 }
 \value{
-Returns the same output as bootstrap_ci by default,
+Returns the same output as \code{bootstrap_ci} by default,
   or the combined list (as if you had just run bootstrap_model once with
-  all resamples) if return_combined_list = TRUE
+  all resamples) if \code{return_combined_list = TRUE}
 }
 \description{
 If you run glmmboot on e.g. a grid of computers,
-set return_coefs_instead = TRUE for each.
+set \code{return_coefs_instead = TRUE} for each.
 Then enter them all here. Either just list them out,
 or put them into one list and enter them.
 }

--- a/man/find_bars.Rd
+++ b/man/find_bars.Rd
@@ -7,10 +7,9 @@
 find_bars(form_with_bars)
 }
 \arguments{
-\item{form_with_bars}{A formula used in e.g. lme4 and similar
+\item{form_with_bars}{A formula used in e.g. \code{lme4} and similar
 packages. Typically along the lines:
-y ~ age + (1 | school)
-etc}
+\code{y ~ age + (1 | school)} etc}
 }
 \description{
 Returns the terms with bars from a formula

--- a/man/gen_resampling_index.Rd
+++ b/man/gen_resampling_index.Rd
@@ -7,16 +7,16 @@
 gen_resampling_index(orig_list, sampled_list)
 }
 \arguments{
-\item{orig_list}{List of original data vectors}
+\item{orig_list}{List of original data vectors.}
 
 \item{sampled_list}{Sampled list}
 }
 \value{
-Returns an index vector
+Returns an index vector.
 }
 \description{
-this function takes in original vectors, and resampled editions,
+This function takes in original vectors, and resampled editions,
 it spits back the matching index of the original variables
-for the new resampled ones
+for the new resampled ones.
 }
 \keyword{internal}

--- a/man/gen_samp_lev.Rd
+++ b/man/gen_samp_lev.Rd
@@ -7,16 +7,17 @@
 gen_samp_lev(levels, unique_lim = NULL, reduce_by_one = TRUE)
 }
 \arguments{
-\item{levels}{The levels to sample}
+\item{levels}{The levels to sample.}
 
-\item{unique_lim}{Default NULL; optionally a required number of unique
-elements to have in the sample}
+\item{unique_lim}{Default \code{NULL};
+optionally a required number of unique elements to have in the sample}
 
-\item{reduce_by_one}{Logical, default TRUE; for (potentially) more accurate coverage,
-resample one less than the number of levels in each list}
+\item{reduce_by_one}{Logical, default \code{TRUE};
+for greater coverage,
+resample one less than the number of levels in each list.}
 }
 \value{
-A sample of 'levels'; a vector.
+A sample of \code{levels}; a vector.
 }
 \description{
 For resampling from a single set of levels

--- a/man/gen_sample.Rd
+++ b/man/gen_sample.Rd
@@ -8,18 +8,19 @@ gen_sample(list_of_levels, rand_columns = NULL,
   unique_resample_lim = NULL, reduce_by_one = TRUE)
 }
 \arguments{
-\item{list_of_levels}{list of vectors of levels of each random effect}
+\item{list_of_levels}{List of vectors of levels of each random effect.}
 
-\item{rand_columns}{Default NULL.
-name of columns to randomise over; if NULL, will use
-all in 'list_of_levels'}
+\item{rand_columns}{Default \code{NULL}. Name of columns to randomise over;
+if \code{NULL}, will use all in \code{list_of_levels}}
 
-\item{unique_resample_lim}{Default NULL; optionally set a minimal number of unique levels each sample
+\item{unique_resample_lim}{Default \code{NULL};
+optionally set a minimal number of unique levels each sample
 must produce. Note that it should be a named vector,
 the same as the levels to randomise over.}
 
-\item{reduce_by_one}{Logical, default TRUE; for (potentially) more accurate coverage,
-resample one less than the number of levels in each list}
+\item{reduce_by_one}{Logical, default \code{TRUE};
+for greater coverage,
+resample one less than the number of levels in each list.}
 }
 \value{
 A list of samples

--- a/man/gen_vector_match.Rd
+++ b/man/gen_vector_match.Rd
@@ -8,15 +8,15 @@ gen_vector_match(orig_vector, new_vector,
   current_index = vector("integer", 0))
 }
 \arguments{
-\item{orig_vector}{vector to find indices from}
+\item{orig_vector}{Vector to find indices from.}
 
-\item{new_vector}{vector to match values to (from orig_vector)}
+\item{new_vector}{Vector to match values to (from \code{orig_vector}).}
 
-\item{current_index}{accumulator of the indices so far, for recursion}
+\item{current_index}{Accumulator of the indices so far, for recursion.}
 }
 \value{
-returns a vector of indices from orig_vector that correspond to
-values in new_vector
+Returns a vector of indices from orig_vector that correspond to
+  values in new_vector.
 }
 \description{
 For each value in new_vector, we find the indices of ALL
@@ -24,7 +24,6 @@ matching values in orig_vector. This means that if new_vector
 has duplicates, we'll duplicate the indices from orig_vector too
 }
 \examples{
-
 \donttest{
     orig_vector <- c(1, 1, 2, 3, 3, 3)
     new_vector <- c(1, 2, 1)

--- a/man/get_rand.Rd
+++ b/man/get_rand.Rd
@@ -2,23 +2,21 @@
 % Please edit documentation in R/bootstrap_methods.R
 \name{get_rand}
 \alias{get_rand}
-\title{this takes in a formula with bars
+\title{Takes in a formula with bars
 and gives back the plain names of the columns}
 \usage{
 get_rand(form_with_bars)
 }
 \arguments{
-\item{form_with_bars}{A formula used in e.g. lme4 and similar
+\item{form_with_bars}{A formula used in e.g. \code{lme4} and similar
 packages. Typically along the lines:
-y ~ age + (1 | school)
-etc}
+\code{y ~ age + (1 | school)} etc}
 }
 \value{
-A vector of the variables that
-are treated as random
+A vector of the variables that are treated as random.
 }
 \description{
-this takes in a formula with bars
+Takes in a formula with bars
 and gives back the plain names of the columns
 }
 \examples{

--- a/man/list_of_matrices.Rd
+++ b/man/list_of_matrices.Rd
@@ -7,16 +7,17 @@
 list_of_matrices(list_to_check, allow_null = TRUE)
 }
 \arguments{
-\item{list_to_check}{The "list" (maybe!) to check}
+\item{list_to_check}{The potential list to check}
 
-\item{allow_null}{If an element is NULL, is that OK?}
+\item{allow_null}{If an element is \code{NULL}, is that OK?
+Default \code{TRUE}}
 }
 \value{
-TRUE or FALSE
+Logical
 }
 \description{
 Checks that an object is a list, and also
 that the list is a collection of matrices.
-Currently returns FALSE on an empty list
+Currently returns \code{FALSE} on an empty list
 }
 \keyword{internal}

--- a/man/not_error_check.Rd
+++ b/man/not_error_check.Rd
@@ -2,21 +2,21 @@
 % Please edit documentation in R/bootstrap_methods.R
 \name{not_error_check}
 \alias{not_error_check}
-\title{Checks if the result of bootstrap_coef_est is not error}
+\title{Checks if the result of \code{bootstrap_coef_est} is not error}
 \usage{
 not_error_check(coef_list_list)
 }
 \arguments{
-\item{coef_list_list}{list of results from running bootstrap_coef_est,
-e.g. lapply(1:N, bootstrap_coef_est)}
+\item{coef_list_list}{List of results from running \code{bootstrap_coef_est},
+e.g. \code{lapply(1:N, bootstrap_coef_est)}}
 }
 \value{
-A logical vector, TRUE if the element is indeed a list of matrices
-with non-missing entries
+A logical vector, \code{TRUE} if the element is indeed
+  a list of matrices with non-missing entries
 }
 \description{
-For each element of the list of results
-from running bootstrap_coef_est, checks if it's
-a list of matrices, and that each matrix has no missing values
+For each element of the list of results from running
+\code{bootstrap_coef_est}, checks if it's a list of matrices,
+and that each matrix has no missing values
 }
 \keyword{internal}

--- a/tests/testthat/test-bootstrap_ci.R
+++ b/tests/testthat/test-bootstrap_ci.R
@@ -1,5 +1,6 @@
 context("test-bootstrap_ci")
 
+
 test_that("testing bootstrap_ci", {
     x <- rnorm(20)
     y <- rnorm(20)
@@ -11,10 +12,11 @@ test_that("testing bootstrap_ci", {
                                  resamples = 20,
                                  return_coefs_instead = TRUE)
 
-    expect_equal(class(bootstrap_ci(list_out$base_coef_se,
-                                    list_out$resampled_coef_se)),
-                 "matrix")
+    expect_true(inherits(bootstrap_ci(list_out$base_coef_se,
+                                      list_out$resampled_coef_se),
+                         "matrix"))
 })
+
 
 test_that("testing combine_resampled_lists", {
     x <- rnorm(20)
@@ -43,6 +45,7 @@ test_that("testing combine_resampled_lists", {
                  combine_resampled_lists(list(list_out1, list_out2, list_out3),
                                          return_combined_list = TRUE))
 })
+
 
 test_that("testing interior components", {
     x <- rnorm(20)

--- a/tests/testthat/test-bootstrap_methods.R
+++ b/tests/testthat/test-bootstrap_methods.R
@@ -1,5 +1,6 @@
 context("test-bootstrap_methods")
 
+
 test_that("testing gen_sample", {
     level_list <- list(num = 1:10,
                        let = letters[10:14])
@@ -22,6 +23,7 @@ test_that("testing gen_sample", {
                  NA)
 })
 
+
 test_that("testing gen_samp_lev", {
     expect_equal(length(gen_samp_lev(letters[5:9])),
                  4)
@@ -41,6 +43,7 @@ test_that("testing gen_samp_lev", {
                  NA)
 })
 
+
 test_that("testing gen_vector_match", {
     orig_vector <- c(1001, 1001, 2001, 3001, 3001, 3001)
     new_vector <- c(1001, 2001, 1001)
@@ -48,6 +51,7 @@ test_that("testing gen_vector_match", {
     vector_match <- gen_vector_match(orig_vector, new_vector)
     expect_equal(vector_match, c(1, 2, 3, 1, 2))
 })
+
 
 test_that("testing gen_resampling_index", {
 
@@ -112,7 +116,6 @@ test_that("testing gen_resampling_index", {
 })
 
 test_that("testing get_rand", {
-
     expect_equal(get_rand("y ~ age + (1 | school)"),
                  "school")
 
@@ -130,6 +133,7 @@ test_that("testing get_rand", {
                  vector(mode = "character"))
 })
 
+
 test_that("testing find_bars", {
     expect_equal(find_bars(as.formula("y ~ x + (1 | rand_effect)")),
                  list("1 | rand_effect"))
@@ -138,11 +142,13 @@ test_that("testing find_bars", {
                  list("1 | rand_effect"))
 })
 
+
 test_that("testing calc_entropy", {
     vec_5_6 <- c(5 / 6, 1 / 6)
     expect_equal(calc_entropy(c(rep("a", 5), "b")),
                  -sum(vec_5_6 * log(vec_5_6)))
 })
+
 
 test_that("testing list_of_matrices", {
     listlist_of_maybe_matrices <- list(
@@ -159,6 +165,7 @@ test_that("testing list_of_matrices", {
     expect_false(list_of_matrices(1:10))
     expect_false(list_of_matrices(list()))
 })
+
 
 test_that("testing not_error_check", {
     listlist_of_matrices <- list(

--- a/tests/testthat/test-bootstrap_model.R
+++ b/tests/testthat/test-bootstrap_model.R
@@ -188,6 +188,22 @@ test_that("bootstrap_model parallelism modes", {
                                  num_cores = NULL,
                                  suppress_sampling_message = TRUE),
                  NA)
+    ## we're not actually using glmmTMB here but for testing it's fine
+    expect_error(bootstrap_model(base_model = simple_model,
+                                 base_data = xy_data,
+                                 resamples = 20,
+                                 parallelism = "parallel",
+                                 num_cores = NULL,
+                                 future_packages = "glmmTMB",
+                                 suppress_sampling_message = TRUE))
+    expect_error(bootstrap_model(base_model = simple_model,
+                                 base_data = xy_data,
+                                 resamples = 20,
+                                 parallelism = "future",
+                                 num_cores = NULL,
+                                 future_packages = "glmmTMB",
+                                 suppress_sampling_message = TRUE),
+                 NA)
 
     skip_on_os("windows")
     expect_error(bootstrap_model(base_model = simple_model,

--- a/tests/testthat/test-bootstrap_model.R
+++ b/tests/testthat/test-bootstrap_model.R
@@ -214,16 +214,23 @@ test_that("bootstrap_model parallelism modes", {
                                  suppress_sampling_message = TRUE),
                  NA)
     ## will set num_cores = parallel::detectCores() - 1L
-    expect_error(bootstrap_model(base_model = simple_model,
+    expect_message(bootstrap_model(base_model = simple_model,
                                  base_data = xy_data,
                                  resamples = 20,
                                  parallelism = "parallel",
-                                 suppress_sampling_message = TRUE),
-                 NA)
-    expect_error(bootstrap_model(base_model = simple_model,
-                                 base_data = xy_data,
-                                 resamples = 20,
-                                 parallelism = "parallel",
-                                 suppress_sampling_message = FALSE),
-                 NA)
+                                 suppress_sampling_message = TRUE))
+    expect_error(suppressMessages(bootstrap_model(
+        base_model = simple_model,
+        base_data = xy_data,
+        resamples = 20,
+        parallelism = "parallel",
+        suppress_sampling_message = TRUE)),
+        NA)
+    expect_error(suppressMessages(bootstrap_model(
+        base_model = simple_model,
+        base_data = xy_data,
+        resamples = 20,
+        parallelism = "parallel",
+        suppress_sampling_message = FALSE),
+        NA))
 })

--- a/tests/testthat/test-bootstrap_model.R
+++ b/tests/testthat/test-bootstrap_model.R
@@ -41,6 +41,11 @@ test_that("bootstrap_model works on test_data", {
                                                   data = test_data,
                                                   family = binomial))
 
+    expect_error(bootstrap_model(base_model = base_run,
+                                 base_data = test_data,
+                                 resamples = 2,
+                                 suppress_sampling_message = FALSE),
+                 NA)
     test_run <- bootstrap_model(base_model = base_run,
                                 base_data = test_data,
                                 resamples = 20)
@@ -191,5 +196,18 @@ test_that("bootstrap_model parallelism modes", {
                                  parallelism = "parallel",
                                  num_cores = 2,
                                  suppress_sampling_message = TRUE),
+                 NA)
+    ## will set num_cores = parallel::detectCores() - 1L
+    expect_error(bootstrap_model(base_model = simple_model,
+                                 base_data = xy_data,
+                                 resamples = 20,
+                                 parallelism = "parallel",
+                                 suppress_sampling_message = TRUE),
+                 NA)
+    expect_error(bootstrap_model(base_model = simple_model,
+                                 base_data = xy_data,
+                                 resamples = 20,
+                                 parallelism = "parallel",
+                                 suppress_sampling_message = FALSE),
                  NA)
 })

--- a/tests/testthat/test-bootstrap_model.R
+++ b/tests/testthat/test-bootstrap_model.R
@@ -88,8 +88,8 @@ test_that("bootstrap_model works on test_data", {
 
     small_data <- test_data[1:6, ]
     small_base_run <- suppressWarnings(glmmTMB::glmmTMB(formula = model_formula,
-                                               data = test_data,
-                                               family = binomial))
+                                                        data = test_data,
+                                                        family = binomial))
     expect_warning(bootstrap_model(base_model = small_base_run,
                                    base_data = small_data,
                                    resamples = 20))
@@ -213,24 +213,12 @@ test_that("bootstrap_model parallelism modes", {
                                  num_cores = 2,
                                  suppress_sampling_message = TRUE),
                  NA)
-    ## will set num_cores = parallel::detectCores() - 1L
-    expect_message(bootstrap_model(base_model = simple_model,
-                                 base_data = xy_data,
-                                 resamples = 20,
-                                 parallelism = "parallel",
-                                 suppress_sampling_message = TRUE))
-    expect_error(suppressMessages(bootstrap_model(
+    expect_error(bootstrap_model(
         base_model = simple_model,
         base_data = xy_data,
         resamples = 20,
-        parallelism = "parallel",
-        suppress_sampling_message = TRUE)),
-        NA)
-    expect_error(suppressMessages(bootstrap_model(
-        base_model = simple_model,
-        base_data = xy_data,
-        resamples = 20,
+        num_cores = 2L,
         parallelism = "parallel",
         suppress_sampling_message = FALSE),
-        NA))
+        NA)
 })

--- a/vignettes/quick_use.Rmd
+++ b/vignettes/quick_use.Rmd
@@ -16,15 +16,18 @@ knitr::opts_chunk$set(
 )
 knitr::opts_chunk$set(cache=TRUE)
 knitr::opts_knit$set(cache.extra = 234) # seed
+options(warnPartialMatchArgs = FALSE,
+        warnPartialMatchDollar = FALSE,
+        warnPartialMatchAttr = FALSE)
 ```
 # glmmboot: Quick Use
 
 For even quicker usage instructions, see the README.
 
-The general idea of this package is that you can throw nearly any 
-model built in the typical R fashion. For now, we just need 
+The general idea of this package is that you can throw nearly any
+model built in the typical R fashion. For now, we just need
 a somewhat standard way of extracting fixed effects, and that
-`update` works, which is nearly always the case. 
+`update` works, which is nearly always the case.
 
 Assuming your model is called `base_model`, if
 `coef(summary(base_model))` gives the estimates and standard errors,
@@ -85,8 +88,8 @@ print(bootstrap_over_subj)
 ## Combining Runs
 
 The above might take a long time in a real setting. If it takes far too long on your machine,
-you can ideally run it on a bunch of computers. We don't want each computer to 
-output the fully processed output, only the intermediate outcome. To do this, 
+you can ideally run it on a bunch of computers. We don't want each computer to
+output the fully processed output, only the intermediate outcome. To do this,
 we set `return_coefs_instead = TRUE` for each run:
 ```{r, cache=TRUE}
 b_list1 <- bootstrap_model(base_model = base_run,
@@ -102,7 +105,7 @@ b_list3 <- bootstrap_model(base_model = base_run,
                            resamples = 30,
                            return_coefs_instead = TRUE)
 ```
-Combining this is simple enough. If we've used a few, we don't want to mess around with 
+Combining this is simple enough. If we've used a few, we don't want to mess around with
 even more lists, so we can enter them into the relevant function:
 ```{r, cache=TRUE}
 print(combine_resampled_lists(b_list1, b_list2, b_list3))
@@ -169,8 +172,17 @@ This becomes the default if you don't set `parallelism` but just `num_cores`.
 This uses the very nice `future.apply::future_lapply` function to
 run the models in parallel. Note that you MUST set the `future::plan`
 (see the docs for the `future` and `future.apply` packages) to actually
-make use of multiple cores etc. Using `num_cores` is NOT the right
+make use of multiple cores etc, or else you'll just get a sequential run.
+Using `num_cores` is NOT the right
 way to set the backend, and will cause an error.
+
+Futher, in many cases
+you should supply any packages required for the model to run with the
+argument `future_packages`, because the S3 generic `update()` is used
+to update the model, which won't ship the required globals. You
+don't need this if using `plan(multicore)`, since all futures will
+have access to the same shared memory (and you also don't need it if
+your model is a base model, e.g. `glm`).
 
 This should work well with Windows.
 
@@ -182,7 +194,8 @@ plan("multiprocess") # "multiprocess" should work across Windows / Mac / Linux
 model_results <- bootstrap_model(base_model = some_base_run,
                                  base_data = some_interesting_data,
                                  resamples = 9999,
-                                 parallelism = "future")
+                                 parallelism = "future",
+                                 future_packages = "glmmTMB")
 ```
 
 ### Only setting `num_cores`
@@ -230,7 +243,7 @@ start_time <- Sys.time()
 for (j in 1:total_iterations) {
     ## simulate expensive operation...
     Sys.sleep(2)
-    
+
     print(log_remaining(start_time, Sys.time(), j, total_iterations, "secs"))
 }
 ```
@@ -257,7 +270,7 @@ for (j in 1:num_blocks) {
 
 combined_results <- combine_resampled_lists(results_list)
 ```
-Of course with 50 blocks of size 100, we'd get the equivalent of 5000 samples. 
+Of course with 50 blocks of size 100, we'd get the equivalent of 5000 samples.
 
 ## Zero Inflated
 
@@ -304,13 +317,13 @@ Note the various macros within the `vignette` section of the metadata block abov
 
 The `html_vignette` template includes a basic CSS theme. To override this theme you can specify your own CSS in the document metadata as follows:
 
-    output: 
+    output:
       rmarkdown::html_vignette:
         css: mystyles.css
 
 ## Figures
 
-The figure sizes have been customised so that you can easily put two images side-by-side. 
+The figure sizes have been customised so that you can easily put two images side-by-side.
 
 ```{r, fig.show='hold'}
 plot(1:10)


### PR DESCRIPTION
Requested by CRAN, this PR fixes issues where `class()` was assumed to return a length-one result (mostly was used in testing). All should be done now.

Apart from that, primary change is to add a better default for `parallelism = "parallel"`, and to provide a solve for issues with `parallelism = "future"`:

* if `parallelism = "parallel"` but `num_cores` is left as NULL, we default to using `parallel::detectCores() - 1L` cores. This was in fact the documented behaviour previously, just sadly not the actual behaviour
* `bootstrap_model` (and internal function `bootstrap_runner`) accepts an argument `future_packages` that will be passed along to `future.apply::future.lapply`; this is needed for futures that don't share memory, because the required global isn't visible (when using S3 generics). This is also passed along to README/vignettes/tests etc.

Some very minor documentation and messaging edits rounds out the submission.